### PR TITLE
land-DA repo and hash update

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
         branch = release/land-da-public-v1.0.0
 [submodule "DA_update"]
 	path = DA_update
-	url = https://github.com/NOAA-EPIC/land-DA_update.git
-        branch = release/land-da-public-v1.0.0
+	url = https://github.com/ufs-community/land-DA.git
+        branch = develop
 [submodule "vector2tile"]
 	path = vector2tile
 	url = https://github.com/NOAA-PSL/land-vector2tile.git


### PR DESCRIPTION
- The PR is to reflect the GitHub migration to https://github.com/ufs-community/land-DA and submodule hash update is needed.