### PR TITLE
Add BASELINE option, PR template, and git action minor update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,36 @@
+## Description
+<!--
+Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
+-->
+
+### Anticipated changes to regression tests:
+- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->
+
+## Subcomponents involved:
+- [ ] DA_update
+- [ ] vector2tile
+- [ ] ufs-land-driver
+- [ ] none
+
+## Linked PR's and Issues:
+<!--
+Please link dependent pull requests.
+EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>
+
+Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
+EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
+-->
+
+### Testing (for CM's):
+- RDHPCS
+    - [ ] Hera
+    - [ ] Orion
+    - [ ] Jet
+    - [ ] Gaea
+    - [ ] Cheyenne
+- CI
+  - [ ] Completed
+- PW-Clouds
+  - [ ] AWS
+  - [ ] AZURE
+  - [ ] GCP

--- a/.github/workflows/landda_ci_cd.yml
+++ b/.github/workflows/landda_ci_cd.yml
@@ -2,9 +2,9 @@ name: Continuous Delivery of Land DA Container
 
 on:
   push:
-    branches: [ "release/public-v1.0.0" ]
+    branches: [ "develop" ]
   pull_request:
-    branches: [ "release/public-v1.0.0" ]
+    branches: [ "develop" ]
 
 jobs:
   deploy:

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
         branch = release/land-da-public-v1.0.0
 [submodule "DA_update"]
 	path = DA_update
-	url = https://github.com/jkbk2004/land-DA.git
-        branch = feature/sync
+	url = https://github.com/ufs-community/land-DA.git
+        branch = develop
 [submodule "vector2tile"]
 	path = vector2tile
 	url = https://github.com/NOAA-PSL/land-vector2tile.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
         branch = release/land-da-public-v1.0.0
 [submodule "DA_update"]
 	path = DA_update
-	url = https://github.com/ufs-community/land-DA.git
-        branch = develop
+	url = https://github.com/jkbk2004/land-DA.git
+        branch = feature/sync
 [submodule "vector2tile"]
 	path = vector2tile
 	url = https://github.com/NOAA-PSL/land-vector2tile.git

--- a/do_submit_cycle.sh
+++ b/do_submit_cycle.sh
@@ -24,10 +24,13 @@ export KEEPWORKDIR="YES"
 ############################
 # ensure necessary envars are set
 envars=("exp_name" "STARTDATE" "ENDDATE" "LANDDAROOT" "LANDDA_INPUTS" "CYCLEDIR" \
-        "LANDDA_EXPTS" "PYTHON" "BUILDDIR" "atmos_forc" "OBSDIR" "WORKDIR" \
+        "LANDDA_EXPTS" "BUILDDIR" "atmos_forc" "OBSDIR" "WORKDIR" \
         "OUTDIR" "TEST_BASEDIR" "JEDI_EXECDIR" "JEDI_STATICDIR" "ensemble_size" \
         "FCSTHR" "RES" "TPATH" "TSTUB" "cycles_per_job" "ICSDIR" "DA_config" \
-        "DA_config00" "DA_config06" "DA_config12" "DA_config18")
+        "DA_config00" "DA_config06" "DA_config12" "DA_config18" "BASELINE")
+if [[ ! $BASELINE =~ 'hera.internal' ]]; then
+  envars=("PYTHON")
+fi
 
 for var in "${envars[@]}"; do
   if [ -z "${!var}" ]; then
@@ -43,7 +46,9 @@ fi
 ############################
 # check that modules are loaded in the environment
 
-${CYCLEDIR}/module_check.sh
+if [[ ! $BASELINE =~ 'hera.internal' ]]; then
+  ${CYCLEDIR}/module_check.sh
+fi
 
 if [[ $? -ne 0 ]]; then
   exit 1
@@ -83,11 +88,18 @@ fi
 
 export DADIR=${CYCLEDIR}/DA_update/
 export DAscript=${DADIR}/do_landDA.sh
-export MPIEXEC=`which mpiexec`
+export MPIEXEC='srun'
+export LANDDADIR=${DADIR}
 
 export analdate=${CYCLEDIR}/analdates.sh
 export incdate=${CYCLEDIR}/incdate.sh
 
+export BUILDDIR=${CYCLEDIR}/build
+if [[ $BASELINE =~ 'hera.internal' ]]; then
+  export JEDI_EXECDIR='/scratch2/NCEPDEV/land/data/jedi/fv3-bundle/build/bin'
+fi
+export JEDI_STATICDIR=${DADIR}/jedi/fv3-jedi/Data/
+export INCR_EXECDIR=${DADIR}/add_jedi_incr/exec/
 ############################
 # read in dates  
 

--- a/do_submit_cycle.sh
+++ b/do_submit_cycle.sh
@@ -88,7 +88,7 @@ fi
 
 export DADIR=${CYCLEDIR}/DA_update/
 export DAscript=${DADIR}/do_landDA.sh
-export MPIEXEC='srun'
+export MPIEXEC=`which mpiexec`
 export LANDDADIR=${DADIR}
 
 export analdate=${CYCLEDIR}/analdates.sh

--- a/do_submit_test.sh
+++ b/do_submit_test.sh
@@ -1,10 +1,10 @@
 #!/bin/bash -e
 
-source settings_cycle_test
+source settings_DA_cycle_gdas
 
 rm -rf ${OUTDIR}
 
-do_submit_cycle.sh settings_cycle_test
+./do_submit_cycle.sh settings_DA_cycle_gdas
 
 
 

--- a/land_mods
+++ b/land_mods
@@ -1,0 +1,3 @@
+module purge
+module load  intel/2020.2 
+module load  netcdf/4.7.0

--- a/release.environment
+++ b/release.environment
@@ -5,7 +5,9 @@ export LANDDAROOT=${LANDDAROOT:-`dirname $PWD`}
 export LANDDA_INPUTS=${LANDDA_INPUTS:-${LANDDAROOT}/inputs}
 export CYCLEDIR=$(pwd) 
 export LANDDA_EXPTS=${LANDDA_EXPTS:-${LANDDAROOT}/landda_expts}
-export PYTHON=`which python3`
+if [[ ! $BASELINE =~ 'hera.internal' ]]; then
+  export PYTHON=`which python`
+fi
 export BUILDDIR=${BUILDDIR:-${CYCLEDIR}/build}
 
 #Change some variables if working with a container

--- a/settings_DA_cycle_gdas
+++ b/settings_DA_cycle_gdas
@@ -1,7 +1,8 @@
 # Settings file for submit_cycle, for running the DA_IMS_test 
 
 # experiment name
-export exp_name=DA_GHCN_test
+export exp_name=DA_GHCN_internal
+export BASELINE=hera.internal
 
 #GDAS forcing is available for 2016
 STARTDATE=2016010118

--- a/settings_DA_test
+++ b/settings_DA_test
@@ -29,7 +29,7 @@ OBS_TYPES=("GHCN" )   # format: ("OBS1" "OBS2")
 JEDI_TYPES=("DA" )   # format ("DA" "HOFX") 
 
 #  DA window lenth. Will generally be the same as the FCSTLEN 
-WINLEN=6
+WINLEN=24
 
 # YAMLS. Options, either:
 # 1. "construct" to construct the YAML name, based on requested obs types and their availability 

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash  
 #SBATCH --job-name=offline_noahmp
-#SBATCH --account=nems
+#SBATCH --account=da-cpu
 #SBATCH --qos=debug
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=6

--- a/submit_cycle.sh
+++ b/submit_cycle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash  
 #SBATCH --job-name=offline_noahmp
-#SBATCH --account=da-cpu
+#SBATCH --account=nems
 #SBATCH --qos=debug
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=6


### PR DESCRIPTION
- Add BASELINE hera.internal option. In case BASELINE option hera.internal, pre-built fv3 and ioda bundles will be loaded.
- PR template: plan to get PR approvals with baseline test across RDHPCS and cloud platforms
- Switch Git action branch to develop
- Need to merge https://github.com/ufs-community/land-DA/pull/1 
- Two options of JEDI fv3 and ioda modules (hera.internal and release-v1.0) were tested for the BASELINE options. The GHCN snow depth DA analysis results are compared for 2016-Jan 1 ~ 2.
- Observation-minus-forecast error statistics are
  - release-v1.0 : mean(|omb|)=136.93,  mean(|oma|)=117.31
  - hera.internal: mean(|omb|)=132.97,  mean(|oma|)=113.14
- See attached figure for background snow depth difference
![snow-depth-diff](https://user-images.githubusercontent.com/38663008/229388863-d7a1ce26-2303-42a3-895b-d1ae40cb8ac4.png)
