### PR TITLE
Feature/ctest update

### DIFF
--- a/modulefiles/landda_orion.intel.lua
+++ b/modulefiles/landda_orion.intel.lua
@@ -81,8 +81,8 @@ setenv("CXX", "mpiicpc")
 setenv("FC", "mpiifort")
 setenv("CMAKE_Platform", "orion.intel")
 
-setenv("EPICHOME", "/work/noaa/epic-ps/role-epic-ps")
-setenv("JEDI_INSTALL", pathJoin(os.getenv("EPICHOME"),"contrib/v1.1"))
+setenv("EPICHOME", "/work/noaa/epic/role-epic")
+setenv("JEDI_INSTALL", pathJoin(os.getenv("EPICHOME"),"contrib/orion/v1.1"))
 
 whatis("Description: UFS build environment")
 

--- a/test/retrieve_data.sh
+++ b/test/retrieve_data.sh
@@ -24,7 +24,7 @@ export PATH=${HOME}/.local/bin:${PATH}
 # set envs
 DATA_ROOT=${project_source_dir}/../inputs
 INPUTDATA_ROOT=${DATA_ROOT}/NEMSfv3gfs
-BL_DATE=20230413
+source ${PATHRT}/bl_date.conf
 INPUTDATA_DATE=20221101
 [[ ! -d ${INPUTDATA_ROOT}/develop-${BL_DATE}/${RT_COMPILER^^} ]] && mkdir -p ${INPUTDATA_ROOT}/develop-${BL_DATE}/${RT_COMPILER^^}
 [[ ! -d ${INPUTDATA_ROOT}/input-data-${INPUTDATA_DATE} ]] && mkdir -p ${INPUTDATA_ROOT}/input-data-${INPUTDATA_DATE}
@@ -38,7 +38,7 @@ DES_DIR=${RTPWD}/datm_cdeps_lnd_gswp3
 [[ ! -d ${DES_DIR} ]] && mkdir -p ${DES_DIR}
 echo ${DES_DIR}
 cd $DES_DIR
-aws s3 sync --no-sign-request ${AWS_URL}/develop-${BL_DATE}/${RT_COMPILER^^}/datm_cdeps_lnd_gswp3 .
+aws s3 sync --no-sign-request ${AWS_URL}/develop-${BL_DATE}/datm_cdeps_lnd_gswp3_${RT_COMPILER,,} .
 cd ${project_source_dir}
 
 # DATM data

--- a/test/run_ufs_datm_lnd.sh
+++ b/test/run_ufs_datm_lnd.sh
@@ -98,7 +98,8 @@ cp ${PATHRT}/parm/noahmptable.tbl noahmptable.tbl
 
 # start runs
 echo "Start ufs-cdeps-land model run with TASKS: ${TASKS}"
-mpiexec -n ${TASKS} ./ufs_model
+export MPIRUN=${MPIRUN:-`which mpiexec`}
+${MPIRUN} -n ${TASKS} ./ufs_model
 
 #
 echo "Now check model output with ufs-wm baseline!"

--- a/test/run_ufs_datm_lnd.sh
+++ b/test/run_ufs_datm_lnd.sh
@@ -14,7 +14,7 @@ export MACHINE_ID=${MACHINE_ID:-linux}
 TEST_NAME=datm_cdeps_lnd_gswp3
 PATHRT=${project_source_dir}/ufs-weather-model/tests
 RT_COMPILER=${RT_COMPILER:-intel}
-ATOL="1e-8"
+ATOL="1e-7"
 source ${PATHRT}/detect_machine.sh
 source ${PATHRT}/rt_utils.sh
 source ${PATHRT}/default_vars.sh
@@ -30,7 +30,7 @@ elif [[ $MACHINE_ID = hera.* ]]; then
 else
   echo "Warning: MACHINE_ID is default, users will have to define INPUTDATA_ROOT and RTPWD by themselives"
 fi
-BL_DATE=20230413
+source ${PATHRT}/bl_date.conf
 RTPWD=${RTPWD:-$DISKNM/NEMSfv3gfs/develop-${BL_DATE}/${RT_COMPILER^^}}
 INPUTDATA_ROOT=${INPUTDATA_ROOT:-$DISKNM/NEMSfv3gfs/input-data-20221101}
 
@@ -92,6 +92,9 @@ if [[ $DATM_CDEPS = 'true' ]]; then
   atparse < ${PATHRT}/parm/${DATM_IN_CONFIGURE:-datm_in} > datm_in
   atparse < ${PATHRT}/parm/${DATM_STREAM_CONFIGURE:-datm.streams.IN} > datm.streams
 fi
+
+# NoahMP table file
+cp ${PATHRT}/parm/noahmptable.tbl noahmptable.tbl
 
 # start runs
 echo "Start ufs-cdeps-land model run with TASKS: ${TASKS}"


### PR DESCRIPTION
## Description
Update  Orion modulefiles as well as the test_ufs_datm_land scripts to reflect recent changes of Orion role account and ufs_datm_land model updates.

How to test:
In your build folder:
../test/retrieve_data.sh/work2/noaa/epic-ps/ycteng/case/20230808/land-DA_workflow
salloc --ntasks 8 --exclusive --qos=debug --partition=debug --time=00:30:00 --account=epic
module use ../modulefiles && module load landda_orion.intel
export JEDI_EXECDIR=${JEDI_INSTALL}/fv3-bundle/build/bin
export RTPWD=/work2/noaa/epic-ps/ycteng/case/20230808/inputs/NEMSfv3gfs/develop-20230804/INTEL
export INPUTDATA_ROOT=/work2/noaa/epic-ps/ycteng/case/20230808/inputs/NEMSfv3gfs/input-data-20221101
ctest

Tests have been done on both Hera and Orion. Just be aware that the retrieve_data.sh step will take a while on Hera due to its extremely slow external internet connection.

### Anticipated changes to regression tests:
- [x] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] DA_update
- [ ] vector2tile
- [ ] ufs-land-driver
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [x] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
