### PR TITLE
Setting UFS-WM hash in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ ExternalProject_Add(ufs-weather-model
   PREFIX ${CMAKE_CURRENT_BINARY_DIR}/ufs-weather-model
   GIT_REPOSITORY https://github.com/ufs-community/ufs-weather-model
   GIT_SUBMODULES_RECURSE TRUE
-  GIT_TAG develop
+  GIT_TAG 24f5a415173e625606a65b90163464adcf2770c6
   SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/ufs-weather-model
   CMAKE_ARGS ${SOURCE_DIR} -DAPP=LND -DMPI=ON -DCMAKE_BUILD_TYPE=Release
   INSTALL_COMMAND cmake


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- UFS-WM NOAH-MP component was updated: https://github.com/ufs-community/ufs-weather-model/pull/1845
- NOAH-MP update requires Spack Stack 1.5.1. However, current land DA workflow develop branch uses Spack Stack 1.3.0
- Thus, reset to the UFS-WM Jan 24 2024 hash: https://github.com/ufs-community/ufs-weather-model/commit/24f5a415173e625606a65b90163464adcf2770c6

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] DA_update
- [ ] vector2tile
- [ ] ufs-land-driver
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP

## For reproducibility test on hera
1. git clone -b  ufs-wm-hash https://github.com/jkbk2004/land-DA_workflow --recursive
2. ln -fs /scratch2/NAGAPE/epic/UFS_Land-DA/inputs
3. cd land-DA_workflow/
4. module use modulefiles && module load landda_hera.intel
5. mkdir build && cd build
6. ecbuild .. && make -j 8
7. salloc -q debug -t 0:30:00 --nodes=2 -A <account>
8. ctest
9. cd ..
10. edit submit_cycle.sh: --cpus-per-task=4 and account
11. ./do_submit_cycle.sh settings_DA_cycle_gswp3
