### PR TITLE
Archive log files and post to s3

### DIFF
--- a/test/ci/Jenkinsfile
+++ b/test/ci/Jenkinsfile
@@ -148,14 +148,15 @@ pipeline {
         '''
         }
       }	      
-	 post {
-                            always {
-                                // Archive the test log files
-                                sh 'cd "${}" && tar --create --gzip --verbose --dereference --file "${WORKSPACE}/${}/test_logs-${PLATFORM}-${COMPILER}.tgz" */log.generate_FV3LAM_wflow */log/* ${WORKSPACE}/${PLATFORM}/tests/ctest/_tests_*yaml summary*txt ${WORKSPACE}/${PLATFORM}/tests/ctest/log.*'
-                                // Remove the data sets from the experiments directory to conserve disk space
-                                sh 'find "${EXPERIMENT_BASE_DIR}" -regextype posix-extended -regex "^.*(orog|[0-9]{10})$" -type d | xargs rm -rf'
-                                s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.SRW_PLATFORM}/*_test_results-*-*.txt", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false], [bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.PLATFORM}/test_logs-${env.PLATFORM}-${env.COMPILER}.tgz", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
-                            }
-                        }     
-                     }
-                  } 
+
+	}
+	post {
+	    always {
+		// Archive the test log files
+		sh 'cd "${}" && tar --create --gzip --verbose --dereference --file "${WORKSPACE}/${}/test_logs-${PLATFORM}-${COMPILER}.tgz" */log.generate_FV3LAM_wflow */log/* ${WORKSPACE}/${PLATFORM}/tests/ctest/_tests_*yaml summary*txt ${WORKSPACE}/${PLATFORM}/tests/ctest/log.*'
+		// Remove the data sets from the experiments directory to conserve disk space
+		sh 'find "${EXPERIMENT_BASE_DIR}" -regextype posix-extended -regex "^.*(orog|[0-9]{10})$" -type d | xargs rm -rf'
+		s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.SRW_PLATFORM}/*_test_results-*-*.txt", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false], [bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.PLATFORM}/test_logs-${env.PLATFORM}-${env.COMPILER}.tgz", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
+	    }
+	}     
+} 

--- a/test/ci/Jenkinsfile
+++ b/test/ci/Jenkinsfile
@@ -111,8 +111,14 @@ pipeline {
         ecbuild ../ && make -j4
         echo $(pwd)
         ctest
+	export machine_name_logs=$(echo $machine | awk '{ print tolower($1) }')
+
+
+        tar --create --gzip --verbose --dereference --file "${machine_name_logs}.tgz" ${WORKSPACE}/tests/logs/*.log
+
         '''
-      }
+        s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "**/*tgz*", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
+
     }    
     stage('Run Land DA Workflow on Hercules') {
         agent {
@@ -148,15 +154,7 @@ pipeline {
         '''
         }
       }	      
-
-	}
-	post {
-	    always {
-		// Archive the test log files
-		sh 'cd "${}" && tar --create --gzip --verbose --dereference --file "${WORKSPACE}/${}/test_logs-${PLATFORM}-${COMPILER}.tgz" */log.generate_FV3LAM_wflow */log/* ${WORKSPACE}/${PLATFORM}/tests/ctest/_tests_*yaml summary*txt ${WORKSPACE}/${PLATFORM}/tests/ctest/log.*'
-		// Remove the data sets from the experiments directory to conserve disk space
-		sh 'find "${EXPERIMENT_BASE_DIR}" -regextype posix-extended -regex "^.*(orog|[0-9]{10})$" -type d | xargs rm -rf'
-		s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.SRW_PLATFORM}/*_test_results-*-*.txt", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false], [bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.PLATFORM}/test_logs-${env.PLATFORM}-${env.COMPILER}.tgz", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
-	    }
-	}     
-} 
+    }
+  }
+}
+	

--- a/test/ci/Jenkinsfile
+++ b/test/ci/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
     stage('Launch SonarQube') {
             steps {
                 script {
-                    build job: '/land-da/land-da-sonarqube', parameters: [
+                    build job: '/land-DA_workflow/land-da-sonarqube', parameters: [
                         string(name: 'BRANCH_NAME', value: env.CHANGE_BRANCH ?: 'develop'),
                         string(name: 'FORK_NAME', value: env.CHANGE_FORK ?: '')
                     ], wait: false

--- a/test/ci/Jenkinsfile
+++ b/test/ci/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
 
         '''
         s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: true, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "**/*tgz*", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
-
+      }
     }    
     stage('Run Land DA Workflow on Hercules') {
         agent {
@@ -154,7 +154,6 @@ pipeline {
         '''
         }
       }	      
-    }
   }
 }
 	

--- a/test/ci/Jenkinsfile
+++ b/test/ci/Jenkinsfile
@@ -146,7 +146,16 @@ pipeline {
         sh '''
         
         '''
-      }
-    }
-  }  
-}
+        }
+      }	      
+	 post {
+                            always {
+                                // Archive the test log files
+                                sh 'cd "${}" && tar --create --gzip --verbose --dereference --file "${WORKSPACE}/${}/test_logs-${PLATFORM}-${COMPILER}.tgz" */log.generate_FV3LAM_wflow */log/* ${WORKSPACE}/${PLATFORM}/tests/ctest/_tests_*yaml summary*txt ${WORKSPACE}/${PLATFORM}/tests/ctest/log.*'
+                                // Remove the data sets from the experiments directory to conserve disk space
+                                sh 'find "${EXPERIMENT_BASE_DIR}" -regextype posix-extended -regex "^.*(orog|[0-9]{10})$" -type d | xargs rm -rf'
+                                s3Upload consoleLogLevel: 'INFO', dontSetBuildResultOnFailure: false, dontWaitForConcurrentBuildCompletion: false, entries: [[bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.SRW_PLATFORM}/*_test_results-*-*.txt", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false], [bucket: 'noaa-epic-prod-jenkins-artifacts', excludedFile: '', flatten: false, gzipFiles: false, keepForever: false, managedArtifacts: true, noUploadOnFailure: false, selectedRegion: 'us-east-1', showDirectlyInBrowser: false, sourceFile: "${env.PLATFORM}/test_logs-${env.PLATFORM}-${env.COMPILER}.tgz", storageClass: 'STANDARD', uploadFromSlave: false, useServerSideEncryption: false]], pluginFailureResultConstraint: 'FAILURE', profileName: 'main', userMetadata: []
+                            }
+                        }     
+                     }
+                  } 


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->

Find way to archive ctest logs and post them to AWS s3 data bucket, similar to SRW structure.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] DA_update
- [ ] vector2tile
- [ ] ufs-land-driver
- [ ] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->

### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
