### PR TITLE
Add script for running J-job scripts without Rocoto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ parm/*.xml
 parm/*.db
 parm/*.out
 parm/*.err
+parm/*.log
 
 __pycache__
 *.swp

--- a/parm/run_without_rocoto.sh
+++ b/parm/run_without_rocoto.sh
@@ -12,14 +12,14 @@
 
 export MACHINE="hera"
 export ACCOUNT="nems"
-export FORCING="era5"
+export FORCING="gswp3"
 
 if [ "${MACHINE}" = "hera" ]; then
-  export EXP_BASEDIR="/scratch2/NCEPDEV/fv3-cam/Chan-hoo.Jeon/landda_test"
+  export EXP_BASEDIR="/scratch2/NCEPDEV/fv3-cam/Chan-hoo.Jeon/landda_nonrocoto"
   export JEDI_INSTALL="/scratch2/NAGAPE/epic/UFS_Land-DA/jedi"
   export LANDDA_INPUTS="/scratch2/NAGAPE/epic/UFS_Land-DA/inputs"
 elif [ "${MACHINE}" = "orion" ]; then
-  export EXP_BASEDIR="/work/noaa/epic/chjeon/landda_test"
+  export EXP_BASEDIR="/work/noaa/epic/chjeon/landda_nonrocoto"
   export JEDI_INSTALL="/work/noaa/epic/UFS_Land-DA/jedi"
   export LANDDA_INPUTS="/work/noaa/epic/UFS_Land-DA/inputs"
 fi
@@ -41,6 +41,7 @@ export LOG="${EXP_BASEDIR}/tests"
 export PATHRT="${EXP_BASEDIR}"
 
 export ATMOS_FORC="${FORCING}"
+export NPROC_JEDI="${NPROCS_ANA}"
 
 if [ "${FORCING}" = "era5" ]; then
   export CTIME="2019122100"
@@ -57,7 +58,7 @@ fi
 echo " ... PREP_EXP running ... "
 ${CYCLEDIR}/jobs/JLANDDA_PREP_EXP
 export err=$?
-if [ $err != 0 ]; then
+if [ $err = 0 ]; then
   echo " === PREP_EXP completed successfully === "
 else
   echo " ERROR: PREP_EXP failed !!! "
@@ -67,7 +68,7 @@ fi
 echo " ... PREP_OBS running ... "
 ${CYCLEDIR}/jobs/JLANDDA_PREP_OBS
 export err=$?
-if [ $err != 0 ]; then
+if [ $err = 0 ]; then
   echo " === PREP_OBS completed successfully === "
 else
   echo " ERROR: PREP_OBS failed !!! "
@@ -77,7 +78,7 @@ fi
 echo " ... PREP_BMAT running ... "
 ${CYCLEDIR}/jobs/JLANDDA_PREP_BMAT
 export err=$?
-if [ $err != 0 ]; then
+if [ $err = 0 ]; then
   echo " === PREP_BMAT completed successfully === "
 else
   echo " ERROR: PREP_BMAT failed !!! "
@@ -87,7 +88,7 @@ fi
 echo " ... RUN_ANA running ... "
 ${CYCLEDIR}/jobs/JLANDDA_RUN_ANA
 export err=$?
-if [ $err != 0 ]; then
+if [ $err = 0 ]; then
   echo " === RUN_ANA completed successfully === "
 else
   echo " ERROR: RUN_ANA failed !!! "
@@ -95,9 +96,9 @@ else
 fi
 
 echo " ... RUN_FCST running ... "
-${CYCLEDIR}/jobs/JLANDDDA_RUN_FCST
+${CYCLEDIR}/jobs/JLANDDA_RUN_FCST
 export err=$?
-if [ $err != 0 ]; then
+if [ $err = 0 ]; then
   echo " === RUN_FCST completed successfully === "
 else
   echo " ERROR: RUN_FCST failed !!! "

--- a/parm/run_without_rocoto.sh
+++ b/parm/run_without_rocoto.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+#SBATCH --job-name=land_da_wflow
+#SBATCH --account=nems
+#SBATCH --qos=debug
+#SBATCH --nodes=1
+#SBATCH --tasks-per-node=6
+#SBATCH --cpus-per-task=1
+#SBATCH -t 00:30:00
+#SBATCH -o log_landda_wflow.%j.log
+#SBATCH -e err_landda_wflow.%j.err
+
+
+export MACHINE="hera"
+export ACCOUNT="nems"
+export FORCING="era5"
+
+if [ "${MACHINE}" = "hera" ]; then
+  export EXP_BASEDIR="/scratch2/NCEPDEV/fv3-cam/Chan-hoo.Jeon/landda_test"
+  export JEDI_INSTALL="/scratch2/NAGAPE/epic/UFS_Land-DA/jedi"
+  export LANDDA_INPUTS="/scratch2/NAGAPE/epic/UFS_Land-DA/inputs"
+elif [ "${MACHINE}" = "orion" ]; then
+  export EXP_BASEDIR="/work/noaa/epic/chjeon/landda_test"
+  export JEDI_INSTALL="/work/noaa/epic/UFS_Land-DA/jedi"
+  export LANDDA_INPUTS="/work/noaa/epic/UFS_Land-DA/inputs"
+fi
+
+export RES="96"
+export FCSTHR="24"
+export NPROCS_ANA="6"
+export NPROCS_FCST="6"
+export OBS_TYPES="GHCN"
+export fv3bundle_vn="psl_develop"
+export DAtype="letkfoi_snow"
+export SNOWDEPTHVAR="snwdph"
+export TSTUB="oro_C96.mx100"
+export WORKDIR="${EXP_BASEDIR}/workdir"
+export CYCLEDIR="${EXP_BASEDIR}/land-DA_workflow"
+export EXECdir="${CYCLEDIR}/exec"
+export OUTDIR="${EXP_BASEDIR}/landda_expts/DA_${FORCING}_test"
+export LOG="${EXP_BASEDIR}/tests"
+export PATHRT="${EXP_BASEDIR}"
+
+export ATMOS_FORC="${FORCING}"
+
+if [ "${FORCING}" = "era5" ]; then
+  export CTIME="2019122100"
+  export PTIME="2019122000"
+  export NTIME="2019122200"
+elif [ "${FORCING}" = "gswp3" ]; then
+  export CTIME="2000010300"
+  export PTIME="2000010200"
+  export NTIME="2000010400"
+fi
+
+# Call J-job scripts
+#
+echo " ... PREP_EXP running ... "
+${CYCLEDIR}/jobs/JLANDDA_PREP_EXP
+export err=$?
+if [ $err != 0 ]; then
+  echo " === PREP_EXP completed successfully === "
+else
+  echo " ERROR: PREP_EXP failed !!! "
+  exit 1
+fi
+
+echo " ... PREP_OBS running ... "
+${CYCLEDIR}/jobs/JLANDDA_PREP_OBS
+export err=$?
+if [ $err != 0 ]; then
+  echo " === PREP_OBS completed successfully === "
+else
+  echo " ERROR: PREP_OBS failed !!! "
+  exit 2
+fi
+
+echo " ... PREP_BMAT running ... "
+${CYCLEDIR}/jobs/JLANDDA_PREP_BMAT
+export err=$?
+if [ $err != 0 ]; then
+  echo " === PREP_BMAT completed successfully === "
+else
+  echo " ERROR: PREP_BMAT failed !!! "
+  exit 3
+fi
+
+echo " ... RUN_ANA running ... "
+${CYCLEDIR}/jobs/JLANDDA_RUN_ANA
+export err=$?
+if [ $err != 0 ]; then
+  echo " === RUN_ANA completed successfully === "
+else
+  echo " ERROR: RUN_ANA failed !!! "
+  exit 4
+fi
+
+echo " ... RUN_FCST running ... "
+${CYCLEDIR}/jobs/JLANDDDA_RUN_FCST
+export err=$?
+if [ $err != 0 ]; then
+  echo " === RUN_FCST completed successfully === "
+else
+  echo " ERROR: RUN_FCST failed !!! "
+  exit 5
+fi
+


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
Add a script for running the J-job scripts without Rocoto to the `parm` directory.
```
cd parm
sbatch run_without_rocoto.sh
```

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] DA_update (ufs-community/land-DA)
- [ ] ufsLand.fd (NOAA-EPIC/ufs-land-driver-emc-dev)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] vector2tile_converter.fd (NOAA-PSL/land-vector2tile)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
--> Closes Issue #66 

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [x] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
