### PR TITLE
Extend container support to all Tier 1 platforms

### DIFF
--- a/do_submit_cycle.sh
+++ b/do_submit_cycle.sh
@@ -87,7 +87,7 @@ fi
 if [[ -e ${CYCLEDIR}/exec/ufsLand.exe ]]; then
   export LSMexec=${CYCLEDIR}/exec/ufsLand.exe
 else
-  export LSMexec=${CYCLEDIR}/sorc/ufs-land-driver-emc-dev/run/ufsLand.exe
+  export LSMexec=${CYCLEDIR}/sorc/ufsLand.fd/run/ufsLand.exe
 fi
 
 export DADIR=${CYCLEDIR}/sorc/DA_update/

--- a/doc/source/BuildingRunningTesting/Container.rst
+++ b/doc/source/BuildingRunningTesting/Container.rst
@@ -99,19 +99,21 @@ On many NOAA :term:`RDHPCS` systems, a container named ``ubuntu20.04-intel-landd
 
 .. table:: Locations of Pre-Built Containers
 
-   +--------------+--------------------------------------------------------+
-   | Machine      | File location                                          |
-   +==============+========================================================+
-   | Derecho      | /glade/work/epicufsrt/contrib/containers               |
-   +--------------+--------------------------------------------------------+
-   | Gaea         | /lustre/f2/dev/role.epic/contrib/containers            |
-   +--------------+--------------------------------------------------------+
-   | Hera         | /scratch1/NCEPDEV/nems/role.epic/containers            |
-   +--------------+--------------------------------------------------------+
-   | Jet          | /mnt/lfs4/HFIP/hfv3gfs/role.epic/containers            |
-   +--------------+--------------------------------------------------------+
-   | Orion        | /work/noaa/epic/role-epic/contrib/containers           |
-   +--------------+--------------------------------------------------------+
+   +-----------------+--------------------------------------------------------+
+   | Machine         | File location                                          |
+   +=================+========================================================+
+   | Derecho         | /glade/work/epicufsrt/contrib/containers               |
+   +-----------------+--------------------------------------------------------+
+   | Gaea            | /gpfs/f5/epic/world-shared/containers                  |
+   +-----------------+--------------------------------------------------------+
+   | Hera            | /scratch1/NCEPDEV/nems/role.epic/containers            |
+   +-----------------+--------------------------------------------------------+
+   | Jet             | /mnt/lfs4/HFIP/hfv3gfs/role.epic/containers            |
+   +-----------------+--------------------------------------------------------+
+   | NOAA Cloud      | /contrib/EPIC/containers                               |
+   +-----------------+--------------------------------------------------------+
+   | Orion/Hercules  | /work/noaa/epic/role-epic/contrib/containers           |
+   +-----------------+--------------------------------------------------------+
 
 Users can simply set an environment variable to point to the container: 
 
@@ -244,7 +246,7 @@ Navigate to the ``land-DA_workflow`` directory after it has been successfully co
 
    cd land-DA_workflow
 
-When using a Singularity container, Intel compilers and Intel :term:`MPI` (preferably 2020 versions or newer) need to be available on the host system to properly launch MPI jobs. Generally, this is accomplished by loading a module with a recent Intel compiler and then loading the corresponding Intel MPI. For example, users can modify the following commands to load their system's compiler/MPI combination:
+When using a Singularity container, Intel compilers and Intel :term:`MPI` (preferably 2020 versions or newer) need to be available on the host system to properly launch MPI jobs. The Level 1 systems that have Intel compilers and Intel MPI available are: Hera, Jet, NOAA Cloud, and Orion. Generally, this is accomplished by loading a module with a recent Intel compiler and then loading the corresponding Intel MPI. For example, users can modify the following commands to load their system's compiler/MPI combination:
 
 .. code-block:: console
 
@@ -259,6 +261,27 @@ When using a Singularity container, Intel compilers and Intel :term:`MPI` (prefe
       source /path/to/init/bash
    
    Then they should be able to load the appropriate modules.
+
+The remaining Level 1 systems that do not have Intel MPI available will need to load a different Intel compiler and MPI combination. Refer to :numref:`Table %s <NonIMPICompilers>` for which Intel compiler and MPI to load for these systems.
+
+.. _NonIMPICompilers:
+
+.. table:: Intel compilers and MPIs for non-Intel MPI Level 1 systems
+
+   +-----------------+-------------------------------------------------------------------------+
+   | Machine         | Intel compiler and MPI combinations                                     |
+   +=================+=========================================================================+
+   | Derecho         |  module load intel-oneapi/2023.2.1 cray-mpich/8.1.25                    |
+   +-----------------+-------------------------------------------------------------------------+
+   | Gaea            |  module load intel-classic/2023.1.0 cray-mpich/8.1.25                   |
+   +-----------------+-------------------------------------------------------------------------+
+   | Hercules        |  module load intel-oneapi-compilers/2022.2.1 intel-oneapi-mpi/2021.7.1  |
+   +-----------------+-------------------------------------------------------------------------+
+
+For Derecho and Gaea, an additional script is needed to help set up the land-DA workflow scripts so that the container can run there. 
+
+.. code-block:: console
+      ./setup_container.sh -p=<derecho|gaea>
 
 .. _ConfigureExptC:
 


### PR DESCRIPTION
## Description
This PR extends support for the Land DA develop container to all Tier 1 platforms. To accomplish this, a [new script](https://github.com/NOAA-EPIC/ufs-containers/blob/feature/landda/Docker/landda/setup_container.sh) was added to the ufs-containers repo.

Most T1 platforms have Intel MPI installed and can run the workflow as described in the documentation with the exception of Derecho, Gaea, and Hercules. For these platforms different Intel compilers and MPIs are used and the `setup_container.sh` from the ufs-containers repo needs to run on as well (just on Derecho and Gaea). For Derecho, this script changes the slurm commands to the pbs equivalent commands because that is the job scheduler used there. And for Gaea, this script switches the mpiexec commands to srun and adds additional sbatch commands so that the jobs can run there.

All the relevant information to run this new process was added to the documentation.

Some reorganization occurred in the develop branch, so renaming the submodules path was needed in the `do_submit_cycle.sh` script.

The container was tested with both the era5 and gswp3 cases for all T1 platform. I can provide the locations of these tests if needed.

When this PR is merged the Land DA develop container will need to be rebuilt and pushed to all T1 platforms.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] DA_update (ufs-community/land-DA)
- [ ] ufsLand.fd (NOAA-EPIC/ufs-land-driver-emc-dev)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] vector2tile_converter.fd (NOAA-PSL/land-vector2tile)
- [X] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->

### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Jet
    - [ ] Gaea
    - [ ] Cheyenne
- CI
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
