### PR TITLE
Change path to orog files and simplify ex-scripts

### DIFF
--- a/parm/templates/template.jedi2ufs
+++ b/parm/templates/template.jedi2ufs
@@ -9,7 +9,7 @@
 ! FV3 resolution and path to oro files for restart/perturbation conversion
 
   tile_size = XXRES
-  tile_path = "XXTPATH"
+  tile_path = "FIXlandda/orog_files/"
   tile_fstub = "XXTSTUB"
   
 !------------------- only restart conversion -------------------
@@ -18,7 +18,7 @@
   restart_date = "XXYYYY-XXMM-XXDD XXHH:00:00"
   
 ! Path for static file  
-  static_filename = "FIXlandda/forcing/MODEL_FORCING/static/ufs-land_CXXRES_static_fields.nc"
+  static_filename = "FIXlandda/static/ufs-land_CXXRES_static_fields.nc"
   
 ! Location of vector restart file (vector2tile direction)
 

--- a/parm/templates/template.tile2vector
+++ b/parm/templates/template.tile2vector
@@ -9,7 +9,7 @@
 ! FV3 resolution and path to oro files for restart/perturbation conversion
 
   tile_size = XXRES
-  tile_path = "XXTPATH"
+  tile_path = "FIXlandda/orog_files/"
   tile_fstub = "XXTSTUB"
   
 !------------------- only restart conversion -------------------
@@ -18,7 +18,7 @@
   restart_date = "XXYYYY-XXMM-XXDD XXHH:00:00"
   
 ! Path for static file  
-  static_filename = "FIXlandda/forcing/MODEL_FORCING/static/ufs-land_CXXRES_static_fields.nc"
+  static_filename = "FIXlandda/static/ufs-land_CXXRES_static_fields.nc"
   
 ! Location of vector restart file (vector2tile direction)
 

--- a/parm/templates/template.ufs-noahMP.namelist.era5
+++ b/parm/templates/template.ufs-noahMP.namelist.era5
@@ -1,6 +1,6 @@
 &run_setup
 
-   static_file      = "/FIXlandda/forcing/era5/static/ufs-land_C96_static_fields.nc"
+   static_file      = "/FIXlandda/static/ufs-land_C96_static_fields.nc"
    init_file        = "/FIXlandda/forcing/era5/init/ufs-land_C96_init_2010-12-31_23-00-00.nc"
    forcing_dir      = "/FIXlandda/forcing/era5/datm/C96/"
   

--- a/parm/templates/template.ufs2jedi
+++ b/parm/templates/template.ufs2jedi
@@ -9,7 +9,7 @@
 ! FV3 resolution and path to oro files for restart/perturbation conversion
 
   tile_size = XXRES
-  tile_path = "XXTPATH"
+  tile_path = "FIXlandda/orog_files/"
   tile_fstub = "XXTSTUB"
   
 !------------------- only restart conversion -------------------
@@ -18,7 +18,7 @@
   restart_date = "XXYYYY-XXMM-XXDD XXHH:00:00"
   
 ! Path for static file  
-  static_filename = "FIXlandda/forcing/MODEL_FORCING/static/ufs-land_CXXRES_static_fields.nc"
+  static_filename = "FIXlandda/static/ufs-land_CXXRES_static_fields.nc"
   
 ! Location of vector restart file (vector2tile direction)
 

--- a/parm/templates/template.vector2tile
+++ b/parm/templates/template.vector2tile
@@ -9,7 +9,7 @@
 ! FV3 resolution and path to oro files for restart/perturbation conversion
 
   tile_size = XXRES
-  tile_path = "XXTPATH"
+  tile_path = "FIXlandda/orog_files/"
   tile_fstub = "XXTSTUB"
   
 !------------------- only restart conversion -------------------
@@ -18,7 +18,7 @@
   restart_date = "XXYYYY-XXMM-XXDD XXHH:00:00"
   
 ! Path for static file  
-  static_filename = "FIXlandda/forcing/MODEL_FORCING/static/ufs-land_CXXRES_static_fields.nc"
+  static_filename = "FIXlandda/static/ufs-land_CXXRES_static_fields.nc"
   
 ! Location of vector restart file (vector2tile direction)
 

--- a/scripts/exlandda_analysis.sh
+++ b/scripts/exlandda_analysis.sh
@@ -2,7 +2,7 @@
 
 set -xue
 
-TPATH=${FIXlandda}/forcing/${ATMOS_FORC}/orog_files/
+TPATH=${FIXlandda}/orog_files/
 YYYY=${PDY:0:4}
 MM=${PDY:4:2}
 DD=${PDY:6:2}

--- a/scripts/exlandda_forecast.sh
+++ b/scripts/exlandda_forecast.sh
@@ -3,7 +3,7 @@
 set -xue
 
 MACHINE_ID=${MACHINE}
-TPATH=${FIXlandda}/forcing/${ATMOS_FORC}/orog_files/
+
 YYYY=${PDY:0:4}
 MM=${PDY:4:2}
 DD=${PDY:6:2}

--- a/scripts/exlandda_post_anal.sh
+++ b/scripts/exlandda_post_anal.sh
@@ -6,7 +6,7 @@ set -xue
 # copy restarts to workdir, convert to UFS tile for DA (all members)
 
 MACHINE_ID=${MACHINE}
-TPATH=${FIXlandda}/forcing/${ATMOS_FORC}/orog_files/
+
 YYYY=${PDY:0:4}
 MM=${PDY:4:2}
 DD=${PDY:6:2}
@@ -54,7 +54,6 @@ if [[ ${ATMOS_FORC} == "era5" ]]; then
   sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" tile2vector.namelist
   sed -i -e "s/XXRES/${RES}/g" tile2vector.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" tile2vector.namelist
-  sed -i -e "s#XXTPATH#${TPATH}#g" tile2vector.namelist
 
   export pgm="vector2tile_converter.exe"
   . prep_step
@@ -121,7 +120,6 @@ elif [[ ${ATMOS_FORC} == "gswp3" ]]; then
   sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" jedi2ufs.namelist
   sed -i -e "s/XXRES/${RES}/g" jedi2ufs.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" jedi2ufs.namelist
-  sed -i -e "s#XXTPATH#${TPATH}#g" jedi2ufs.namelist
 
   export pgm="tile2tile_converter.exe"
   . prep_step

--- a/scripts/exlandda_post_anal.sh
+++ b/scripts/exlandda_post_anal.sh
@@ -20,15 +20,6 @@ FREQ=$((${FCSTHR}*3600))
 RDD=$((${FCSTHR}/24))
 RHH=$((${FCSTHR}%24))
 
-# load modulefiles
-BUILD_VERSION_FILE="${HOMElandda}/versions/build.ver_${MACHINE}"
-if [ -e ${BUILD_VERSION_FILE} ]; then
-  . ${BUILD_VERSION_FILE}
-fi
-mkdir -p modulefiles
-cp ${HOMElandda}/modulefiles/build_${MACHINE}_intel.lua $DATA/modulefiles/modules.landda.lua
-module use modulefiles; module load modules.landda
-
 MPIEXEC=`which mpiexec`
 
 FILEDATE=${YYYY}${MM}${DD}.${HH}0000

--- a/scripts/exlandda_post_anal.sh
+++ b/scripts/exlandda_post_anal.sh
@@ -42,7 +42,6 @@ if [[ ${ATMOS_FORC} == "era5" ]]; then
   sed -i -e "s/XXMM/${MM}/g" tile2vector.namelist
   sed -i -e "s/XXDD/${DD}/g" tile2vector.namelist
   sed -i -e "s/XXHH/${HH}/g" tile2vector.namelist
-  sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" tile2vector.namelist
   sed -i -e "s/XXRES/${RES}/g" tile2vector.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" tile2vector.namelist
 
@@ -108,7 +107,6 @@ elif [[ ${ATMOS_FORC} == "gswp3" ]]; then
   sed -i -e "s/XXMM/${MM}/g" jedi2ufs.namelist
   sed -i -e "s/XXDD/${DD}/g" jedi2ufs.namelist
   sed -i -e "s/XXHH/${HH}/g" jedi2ufs.namelist
-  sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" jedi2ufs.namelist
   sed -i -e "s/XXRES/${RES}/g" jedi2ufs.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" jedi2ufs.namelist
 

--- a/scripts/exlandda_pre_anal.sh
+++ b/scripts/exlandda_pre_anal.sh
@@ -39,7 +39,6 @@ if [[ $ATMOS_FORC == "era5" ]]; then
   sed -i -e "s/XXDD/${DD}/g" vector2tile.namelist
   sed -i -e "s/XXHH/${HH}/g" vector2tile.namelist
   sed -i -e "s/XXHH/${HH}/g" vector2tile.namelist
-  sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" vector2tile.namelist
   sed -i -e "s/XXRES/${RES}/g" vector2tile.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" vector2tile.namelist
 
@@ -87,7 +86,6 @@ elif [[ $ATMOS_FORC == "gswp3" ]]; then
   sed -i -e "s/XXDD/${DD}/g" ufs2jedi.namelist
   sed -i -e "s/XXHH/${HH}/g" ufs2jedi.namelist
   sed -i -e "s/XXHH/${HH}/g" ufs2jedi.namelist
-  sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" ufs2jedi.namelist
   sed -i -e "s/XXRES/${RES}/g" ufs2jedi.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" ufs2jedi.namelist
 

--- a/scripts/exlandda_pre_anal.sh
+++ b/scripts/exlandda_pre_anal.sh
@@ -2,7 +2,6 @@
 
 set -xue
 
-TPATH=${FIXlandda}/forcing/${ATMOS_FORC}/orog_files/
 YYYY=${PDY:0:4}
 MM=${PDY:4:2}
 DD=${PDY:6:2}
@@ -43,7 +42,6 @@ if [[ $ATMOS_FORC == "era5" ]]; then
   sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" vector2tile.namelist
   sed -i -e "s/XXRES/${RES}/g" vector2tile.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" vector2tile.namelist
-  sed -i -e "s#XXTPATH#${TPATH}#g" vector2tile.namelist
 
   # submit vec2tile 
   echo '************************************************'
@@ -92,7 +90,6 @@ elif [[ $ATMOS_FORC == "gswp3" ]]; then
   sed -i -e "s/MODEL_FORCING/${ATMOS_FORC}/g" ufs2jedi.namelist
   sed -i -e "s/XXRES/${RES}/g" ufs2jedi.namelist
   sed -i -e "s/XXTSTUB/${TSTUB}/g" ufs2jedi.namelist
-  sed -i -e "s#XXTPATH#${TPATH}#g" ufs2jedi.namelist
 
   # submit tile2tile
   export pgm="tile2tile_converter.exe"

--- a/sorc/test/runtime_vars.sh
+++ b/sorc/test/runtime_vars.sh
@@ -51,7 +51,7 @@ export PYTHON_EXEC=${PYTHON_EXEC:-`which python`}
 # configurations
 export RES=96
 export atmos_forc=era5
-export TPATH="$FIXlandda/forcing/${atmos_forc}/orog_files/"
+export TPATH="$FIXlandda/orog_files/"
 export TSTUB="oro_C${RES}.mx100"
 export GFSv17=NO
 export OBS_TYPES=("GHCN")

--- a/sorc/test/test_vector2tile.sh
+++ b/sorc/test/test_vector2tile.sh
@@ -81,7 +81,6 @@ sed -i -e "s/XXYYYY/${YY}/g" vector2tile.namelist
 sed -i -e "s/XXMM/${MM}/g" vector2tile.namelist
 sed -i -e "s/XXDD/${DD}/g" vector2tile.namelist
 sed -i -e "s/XXHH/${HH}/g" vector2tile.namelist
-sed -i -e "s/MODEL_FORCING/${atmos_forc}/g" vector2tile.namelist
 sed -i -e "s/XXRES/${RES}/g" vector2tile.namelist
 sed -i -e "s#XXTPATH#${TPATH}#g" vector2tile.namelist
 sed -i -e "s/XXTSTUB/${TSTUB}/g" vector2tile.namelist

--- a/sorc/test/testinput/template.vector2tile
+++ b/sorc/test/testinput/template.vector2tile
@@ -18,7 +18,7 @@
   restart_date = "XXYYYY-XXMM-XXDD XXHH:00:00"
   
 ! Path for static file  
-  static_filename = "FIXlandda/forcing/MODEL_FORCING/static/ufs-land_CXXRES_static_fields.nc"
+  static_filename = "FIXlandda/static/ufs-land_CXXRES_static_fields.nc"
   
 ! Location of vector restart file (vector2tile direction)
 

--- a/ush/hofx_analysis_stats.py
+++ b/ush/hofx_analysis_stats.py
@@ -65,9 +65,9 @@ def get_obs_stats(fdir, plottype):
 def plot_scatter():
     print("===== PLOT: SCATTER =====")
     if yaml_data['machine']=='hera':
-        cartopy.config['data_dir']='/scratch2/NCEPDEV/fv3-cam/Chan-hoo.Jeon/tools/NaturalEarth'
-    elif yaml_data['machine']=='orion': 
-        cartopy.config['data_dir']='/home/chjeon/tools/NaturalEarth'
+        cartopy.config['data_dir']='/scratch2/NAGAPE/epic/UFS_Land-DA_Dev/inputs/NaturalEarth'
+    elif yaml_data['machine']=='orion' or yaml_data['machine']=='hercules':
+        cartopy.config['data_dir']='/work/noaa/epic/UFS_Land-DA_Dev/inputs/NaturalEarth'
 
     field_mean=float("{:.2f}".format(np.mean(np.absolute(field))))
     field_std=float("{:.2f}".format(np.std(np.absolute(field))))


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Changes the path to the orography files in the fix directory.
- Fix the missing change in the `post_anal' task for loading modules.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufsLand.fd (NOAA-EPIC/ufs-land-driver-emc-dev)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] vector2tile_converter.fd (NOAA-PSL/land-vector2tile)
- [ ] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->
Resolves Issue #112 

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [ ] Orion
    - [ ] Hercules
    - [ ] Derecho
- CI
  - [x] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
