### PR TITLE
(bugfix) Change MPIRUN from mpiexec to srun for ctest

### DIFF
--- a/sorc/test/hera_ctest.sh
+++ b/sorc/test/hera_ctest.sh
@@ -7,6 +7,8 @@ source ../../versions/build.ver_hera
 module use ../../modulefiles
 module load build_hera_intel
 
+export MPIRUN="srun"
+
 ctest
 
 wait

--- a/sorc/test/hercules_ctest.sh
+++ b/sorc/test/hercules_ctest.sh
@@ -7,6 +7,8 @@ source ../../versions/build.ver_hercules
 module use ../../modulefiles
 module load build_hercules_intel
 
+export MPIRUN="srun"
+
 ctest
 
 wait

--- a/sorc/test/orion_ctest.sh
+++ b/sorc/test/orion_ctest.sh
@@ -7,6 +7,8 @@ source ../../versions/build.ver_orion
 module use ../../modulefiles
 module load build_orion_intel
 
+export MPIRUN="srun"
+
 ctest
 
 wait

--- a/sorc/test/run_ufs_datm_lnd.sh
+++ b/sorc/test/run_ufs_datm_lnd.sh
@@ -97,12 +97,12 @@ fi
 cp ${PATHRT}/parm/noahmptable.tbl noahmptable.tbl
 
 # start runs
-echo "Start ufs-weather-model run"
-if [ "${PLATFORM}" = "hera" ] || [ "${PLATFORM}" = "orion" ] || [ "${PLATFORM}" = "hercules" ]; then 
-  export MPIRUN="srun"
-else
-  export MPIRUN=${MPIRUN:-`which mpiexec`}
-fi
+echo "Start ufs-weather-model run with ${MPIRUN}"
+#if [ "${PLATFORM}" = "hera" ] || [ "${PLATFORM}" = "orion" ] || [ "${PLATFORM}" = "hercules" ]; then 
+#  export MPIRUN="srun"
+#else
+#  export MPIRUN=${MPIRUN:-`which mpiexec`}
+#fi
 ${MPIRUN} -n ${NPROCS_FORECAST} ./ufs_model
 
 #

--- a/sorc/test/run_ufs_datm_lnd.sh
+++ b/sorc/test/run_ufs_datm_lnd.sh
@@ -98,11 +98,6 @@ cp ${PATHRT}/parm/noahmptable.tbl noahmptable.tbl
 
 # start runs
 echo "Start ufs-weather-model run with ${MPIRUN}"
-#if [ "${PLATFORM}" = "hera" ] || [ "${PLATFORM}" = "orion" ] || [ "${PLATFORM}" = "hercules" ]; then 
-#  export MPIRUN="srun"
-#else
-#  export MPIRUN=${MPIRUN:-`which mpiexec`}
-#fi
 ${MPIRUN} -n ${NPROCS_FORECAST} ./ufs_model
 
 #

--- a/sorc/test/test_letkfoi_snowda.sh
+++ b/sorc/test/test_letkfoi_snowda.sh
@@ -83,5 +83,5 @@ ln -fs $JEDI_STATICDIR ./
 cp $project_source_dir/../parm/jedi/gfs-land.yaml .
 
 #
-echo "============================= calling ${JEDI_EXEC}"
+echo "============================= calling ${JEDI_EXEC} with ${MPIRUN}"
 ${MPIRUN} -n $NPROC ${JEDI_EXEC} letkf_land.yaml


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Change 'mpiexec' to 'srun' for Ctests to avoid unstable mpi runs.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->
Resolve Issue #160 

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [x] Orion
    - [x] Hercules
- CI
  - [x] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
