### PR TITLE
Fix Jenkins-nightly-test failure

### DIFF
--- a/.cicd/scripts/land_build.sh
+++ b/.cicd/scripts/land_build.sh
@@ -61,7 +61,7 @@ status=${PIPESTATUS[0]}
 cat sorc/build/log.ecbuild sorc/build/log.make >> ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-build-log.txt
 echo "Pipeline Completed Land-DA build on ${UFS_PLATFORM} ${UFS_COMPILER}. status=$status"
 
-ls -l sorc/build/bin/*.exe sorc/build/lib/*.so
+ls -l sorc/build/bin/*.exe sorc/build/lib64/*.so
 status=$?
 
 git status -u

--- a/.cicd/scripts/land_test.sh
+++ b/.cicd/scripts/land_test.sh
@@ -74,7 +74,7 @@ status=0
 
 if [[ true = ${LAND_DA_RUN_TESTS:=false} ]] ; then
                                         
-    ls -l sorc/build/bin/*.exe sorc/build/lib/*.so
+    ls -l sorc/build/bin/*.exe sorc/build/lib64/*.so
     status=$?
     if [[ ${status} = 0 ]] ; then
 
@@ -100,7 +100,7 @@ if [[ true = ${LAND_DA_RUN_TESTS:=false} ]] ; then
 	set -x
 	cd -
     else
-	echo "Error: bin/* or lib/* not available."
+	echo "Error: bin/* or lib64/* not available."
     fi
 else
 	echo "Pipeline skipping Tests on ${UFS_PLATFORM} (${machine})"


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- With the recent update, the directory name for the libraries was changed from `lib` to `lib64` in `sorc/build`.
- Update the Jenkins CI/CD scripts to fix the failure.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->
Resolve Issue #173 

### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Hercules
- CI
  - [ ] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
