### PR TITLE
[hotfix] Remove hard-coded path in ctest

### DIFF
--- a/sorc/test/parm/letkf_land.yaml
+++ b/sorc/test/parm/letkf_land.yaml
@@ -13,7 +13,7 @@ geometry:
       filetype: fms restart
       skip coupler file: true
       state variables: [orog_filt]
-      datapath: /scratch2/NAGAPE/epic/Chan-hoo.Jeon/landda_dev/land-DA_workflow/fix/FV3_fix_tiled/C96
+      datapath: {{ datapath }}
       filename_orog: C96_oro_data.nc
     derived fields: [nominal_surface_pressure]
 

--- a/sorc/test/test_letkfoi_snowda.sh
+++ b/sorc/test/test_letkfoi_snowda.sh
@@ -29,6 +29,13 @@ done
 mkdir -p obs
 # prepare yaml files
 cp $project_source_dir/test/parm/letkf_land.yaml .
+settings="\
+  'datapath': ${FIXlandda}/FV3_fix_tiled/C${RES}
+" # End of settins variable
+fp_template="letkf_land.yaml"
+fn_namelist="letkf_land.yaml"
+${project_source_dir}/../ush/fill_jinja_template.py -u "${settings}" -t "${fp_template}" -o "${fn_namelist}"
+
 for ii in "${!OBS_TYPES[@]}";
 do
   echo "============================= ${OBS_TYPES[$ii]}" 


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Remove the hard-coded path causing ctest failure from the template.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [ ] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->

### Testing (for CM's):
- RDHPCS
    - [x] Hera
    - [ ] Orion
    - [ ] Hercules
- CI
  - [x] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
