### PR TITLE
Change location of py env for JCB to work dir on gaea-c6

### DIFF
--- a/parm/task_load_modules_run_jjob.sh
+++ b/parm/task_load_modules_run_jjob.sh
@@ -61,7 +61,7 @@ if [ "${task_name}" = "jcb" ]; then
   elif [ "${machine}" = "gaeac6" ]; then
     module use /ncrc/proj/epic/miniconda3/modulefiles
     module load miniconda3/4.12.0
-    conda activate /ncrc/home1/Chan-hoo.Jeon/landda_pyenv
+    conda activate /gpfs/f6/bil-fire8/scratch/Chan-hoo.Jeon/landda_pyenv
   fi
   set -u
   conda list


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Move the location of the python environment for JCB from home dir to work dir on Gaea-C6.

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->


### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Hercules
    - [x] Gaea-c6
- CI
  - [x] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
