### PR TITLE
[develop] set ACCNR for any workflow experiment

### DIFF
--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -24,7 +24,6 @@ echo "HOME=${HOME}"
 echo "UFS_PLATFORM=${UFS_PLATFORM}"
 echo "UFS_COMPILER=${UFS_COMPILER}"
 echo "LAND_DA_EXPERIMENT=${LAND_DA_EXPERIMENT}"
-echo "ACCNR=${ACCNR}"
 
 # Test
 cd ${workspace}
@@ -38,13 +37,19 @@ echo "compiler=${compiler}"
 #export exp_basedir=${expbasedir:-$(dirname $(pwd))}
 export exp_basedir=${exp_basedir:-$(pwd)}
 
+[[ ${machine} = gaeac6   ]] && export ACCNR="bil-fire8" || :  # bil-fire8
+[[ ${machine} = hera     ]] && export ACCNR="nems"      || :  # nral0032
+[[ ${machine} = hercules ]] && export ACCNR="epic"      || :
+[[ ${machine} = orion    ]] && export ACCNR="epic"      || :
+echo "ACCNR=${ACCNR}"
+
 # Choice of experiment that is supported on the machine.
 experiment="${LAND_DA_EXPERIMENT:-}"
 if [[ ${LAND_DA_EXPERIMENT} = default ]] ; then
-	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart" && export ACCNR="bil-fire8" || :  # bil-fire8
-	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart" && export ACCNR="nems"     || :  # nral0032
-	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkf.ghcn.warmstart" && export ACCNR="epic"    || :
-	[[ ${machine} = orion    ]] && experiment="LND.gswp3.3dvar.ghcn.coldstart" && export ACCNR="epic"    || :
+	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart"   || :
+	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
+	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkf.ghcn.warmstart" || :
+	[[ ${machine} = orion    ]] && experiment="LND.gswp3.3dvar.ghcn.coldstart" || :
 else
 	:
 fi


### PR DESCRIPTION
## Description
set ACCNR for any experiment so we can still run on all platforms when not using default experiment.
-

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x] none

## Linked PR's and Issues:
none


### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Hercules
    - [ ] Gaea-c6
- CI
  - [ ] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
