### PR TITLE
Fix to set a default Experiment to run on all platforms

### DIFF
--- a/.cicd/scripts/land_init.sh
+++ b/.cicd/scripts/land_init.sh
@@ -57,6 +57,9 @@ status=${PIPESTATUS[0]}
 git branch
 git log -1 --oneline
 export COMMIT_ID="$(git log -1 --pretty=format:'%H')"
+export COMMIT_LOG="$( git log -1 --date=format:'%Y-%m-%dT%H:%M:%S%z' --format='%cd %h %ce %s' )"
+export COMMIT_DATE="$( git log -1 --date=format:'%Y-%m-%dT%H:%M:%S%z' --format='%cd' )"
+export COMMIT="$( git log -1 --format='%s' | grep '(#[0-9]*)$' | awk '{print $NF}' | sed 's|#|PR-|g' | tr -d '()' )"
 
 /usr/bin/time -p \
 	-o ${workspace}/${UFS_PLATFORM}-${UFS_COMPILER}-time-land_init.json \

--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -46,7 +46,7 @@ echo "ACCNR=${ACCNR}"
 # Choice of experiment that is supported on the machine.
 experiment="${LAND_DA_EXPERIMENT:-}"
 if [[ ${LAND_DA_EXPERIMENT} = default ]] ; then
-	experiment="LND.gswp3.3dvar.ghcn.coldstart" || :
+	experiment="LND.gswp3.3dvar.ghcn.coldstart"
 elif [[ ${LAND_DA_EXPERIMENT} = coverage ]] ; then
 	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart"   || :
 	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :

--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -5,7 +5,7 @@
 #
 # Usage:
 #  UFS_PLATFORM=<platform> UFS_COMPILER=<compiler> [ LAND_DA_EXPERIMENT=<exp> ] .cicd/scripts/run_experiment.sh
-#  .cicd/scripts/land_experiment.sh <platform> <compiler> [ <experiment>|default ]
+#  .cicd/scripts/run_experiment.sh <platform> <compiler> [ <experiment>|default ]
 #
 pwd
 export REPO_NAME="land-DA_workflow"

--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -46,6 +46,8 @@ echo "ACCNR=${ACCNR}"
 # Choice of experiment that is supported on the machine.
 experiment="${LAND_DA_EXPERIMENT:-}"
 if [[ ${LAND_DA_EXPERIMENT} = default ]] ; then
+	experiment="LND.gswp3.3dvar.ghcn.coldstart" || :
+elif [[ ${LAND_DA_EXPERIMENT} = coverage ]] ; then
 	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart"   || :
 	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
 	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkf.ghcn.warmstart" || :


### PR DESCRIPTION
## Description
Selects a specific Experiment Template to run on all platforms to compare performance metrics across machines. 
-

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x] none

## Linked PR's and Issues:
none.


### Testing (for CM's):
- RDHPCS
    - [ ] Hera
    - [ ] Orion
    - [ ] Hercules
    - [ ] Gaea-c6
- CI
  - [ ] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
