### PR TITLE
change zstandard_level in model_config to fix failure in ATML

### DIFF
--- a/parm/templates/template.ATML.input.nml.FV3_GFS_v17_p8_ugwpv1
+++ b/parm/templates/template.ATML.input.nml.FV3_GFS_v17_p8_ugwpv1
@@ -118,6 +118,8 @@
   imp_physics  = 8
   iovr         = 3
   ltaerosol    = .false.
+  mraerosol    = .false.
+  lthailaware  = .false.
   lradar       = .false.
   ttendlim     = -999
   dt_inner     = 720
@@ -228,8 +230,6 @@
   do_sppt      = .false.
   do_shum      = .false.
   do_skeb      = .false.
-  iaufhrs      = -1
-  iau_delthrs  = 0
   use_med_flux = .false.
   frac_grid    = .true.
   cplchm       = .false.
@@ -257,6 +257,8 @@
   pert_mp = .false.
   pert_radtend = .false.
   pert_clds = .false.
+  iaufhrs      = -1
+  iau_delthrs  = 0
   iau_inc_files= ''
   iau_drymassfixer = .false.
   iau_filter_increments = .false.

--- a/parm/templates/template.model_configure
+++ b/parm/templates/template.model_configure
@@ -24,7 +24,7 @@ fv3atm_output_dir:       ./
 filename_base:           'atm' 'sfc'
 output_grid:             cubed_sphere_grid
 output_file:             'netcdf'
-zstandard_level:         5
+zstandard_level:         0
 ideflate:                0
 quantize_mode:           'quantize_bitround'
 quantize_nsd:            0


### PR DESCRIPTION
## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- Change the value of `zstandard_level` in the `model_config` to fix the issue in the forecast task of ATML

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->
Resolve Issue #261 

### Testing (for CM's):
- RDHPCS
    - [x] Gaea-c6
    - [ ] Hera
    - [ ] Hercules
    - [ ] Orion
    - [ ] Ursa
- CI
  - [x] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
