### PR TITLE
Add Ursa to metrics calculations

### DIFF
--- a/.cicd/scripts/land_test.sh
+++ b/.cicd/scripts/land_test.sh
@@ -26,6 +26,7 @@ echo "HOME=${HOME}"
 [[ ${machine} = gaea ]] && NODE_PATH=""
 [[ ${machine} = orion ]] && NODE_PATH="/work/noaa/epic/role-epic"
 [[ ${machine} = hercules ]] && NODE_PATH="/work/noaa/epic/role-epic"
+[[ ${machine} = ursa ]] && NODE_PATH='/scratch4/NAGAPE/epic/role.epic"
 echo "NODE_PATH=${NODE_PATH}"
 
 ( set -x ; ls -ld ${NODE_PATH} && ls -al ${NODE_PATH}/. )
@@ -35,6 +36,7 @@ echo "NODE_PATH=${NODE_PATH}"
 [[ ${machine} = gaea ]] && echo "where are inputs?"
 [[ ${machine} = orion ]] && ls -l /work/noaa/epic/UFS_Land-DA/inputs
 [[ ${machine} = hercules ]] && ls -l /work/noaa/epic/UFS_Land-DA/inputs
+[[ ${machine} = ursa ]] && ls -l /scratch3/NAGAPE/epic/UFS_Land-DA_v3.0/inputs
 
 set -e -u -x
 

--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -41,6 +41,7 @@ export exp_basedir=${exp_basedir:-$(pwd)}
 [[ ${machine} = hera     ]] && export ACCNR="nems"      || :  # nral0032
 [[ ${machine} = hercules ]] && export ACCNR="epic"      || :
 [[ ${machine} = orion    ]] && export ACCNR="epic"      || :
+[[ ${machine} = ursa     ]] && export ACCNR="epic"      || :
 echo "ACCNR=${ACCNR}"
 
 # Choice of experiment that is supported on the machine.
@@ -50,6 +51,7 @@ if [[ ${LAND_DA_EXPERIMENT} = default ]] ; then
 elif [[ ${LAND_DA_EXPERIMENT} = coverage ]] ; then
 	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart"   || :
 	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
+	[[ ${machine} = ursa     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
 	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkf.ghcn.warmstart" || :
 	[[ ${machine} = orion    ]] && experiment="LND.gswp3.3dvar.ghcn.coldstart" || :
 else

--- a/.cicd/scripts/run_experiment.sh
+++ b/.cicd/scripts/run_experiment.sh
@@ -47,13 +47,13 @@ echo "ACCNR=${ACCNR}"
 # Choice of experiment that is supported on the machine.
 experiment="${LAND_DA_EXPERIMENT:-}"
 if [[ ${LAND_DA_EXPERIMENT} = default ]] ; then
-	experiment="LND.gswp3.3dvar.ghcn.coldstart"
+	experiment="LND.gswp3.3dvar.ghcn.DA-fcst.coldstart"
 elif [[ ${LAND_DA_EXPERIMENT} = coverage ]] ; then
-	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.warmstart"   || :
-	[[ ${machine} = hera     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
-	[[ ${machine} = ursa     ]] && experiment="LND.era5.letkf.ghcn.coldstart"  || :
-	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkf.ghcn.warmstart" || :
-	[[ ${machine} = orion    ]] && experiment="LND.gswp3.3dvar.ghcn.coldstart" || :
+	[[ ${machine} = gaeac6   ]] && experiment="LND.era5.3dvar.ims.DA-fcst.warmstart"   || :
+	[[ ${machine} = hera     ]] && experiment="LND.era5.letkfoi.ghcn.DA-fcst.coldstart"  || :
+	[[ ${machine} = ursa     ]] && experiment="LND.era5.letkfoi.ghcn.DA-fcst.coldstart"  || :
+	[[ ${machine} = hercules ]] && experiment="LND.gswp3.letkfoi.ghcn.DA-fcst.warmstart" || :
+	[[ ${machine} = orion    ]] && experiment="LND.gswp3.3dvar.ghcn.DA-fcst.coldstart" || :
 else
 	:
 fi


### PR DESCRIPTION
Add Ursa to Metrics calculations
<!--
Added support for ursa in .cicd/scripts for metrics testing to land_test.sh and run_experiment.sh (2 lines each file)
-->
Land-DA_workflow includes tools to calculate certain metrics (e.g., buildtime, init time, runtime) as part of its suite of tools. These are routine and included for most if not all of the hosts that it runs on. Recently, ursa came on line and is
now available as an option to run Land-DA_workflow. This modification updates the tools to include ursa in the metrics toolbox. It consists of 2 additional lines in run_experiment.sh and 2 additional lines in land_test.sh.


-

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->

## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
--> Closes 1/3 of PLATFORM-1662


### Testing (for CM's):
- RDHPCS
    - [ ] Gaea-c6
    - [ ] Hera
    - [ ] Hercules
    - [ ] Orion
    - [ ] Ursa
- CI
  - [ ] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
