### PR TITLE
Fix NODE_PATH assignment for ursa

### DIFF
--- a/.cicd/scripts/land_test.sh
+++ b/.cicd/scripts/land_test.sh
@@ -26,7 +26,7 @@ echo "HOME=${HOME}"
 [[ ${machine} = gaea ]] && NODE_PATH=""
 [[ ${machine} = orion ]] && NODE_PATH="/work/noaa/epic/role-epic"
 [[ ${machine} = hercules ]] && NODE_PATH="/work/noaa/epic/role-epic"
-[[ ${machine} = ursa ]] && NODE_PATH='/scratch4/NAGAPE/epic/role.epic"
+[[ ${machine} = ursa ]] && NODE_PATH="/scratch4/NAGAPE/epic/role.epic"
 echo "NODE_PATH=${NODE_PATH}"
 
 ( set -x ; ls -ld ${NODE_PATH} && ls -al ${NODE_PATH}/. )


### PR DESCRIPTION


## Description
<!--
Provide a detailed description of what this PR does. What bug does it fix, or what feature does it add? Is a change of answers expected from this PR? Are any library updates included in this PR (modulefiles etc.)?
-->
- The PR corrects a syntax error (quote mismatch) from a previous PR in .cicd/scripts/landtest.sh, line 29 for ursa, 
syntax error was NODE_PATH='/scratch4/NAGAPE/epic/role.epic"
corrected to
NODE_PATH="/scratch4/NAGAPE/epic/role.epic"

### Anticipated changes to regression tests:
- [ ] Is baseline change expected ? <!-- Add "Baseline Change" Label -->
No baseline change expected. Ursa to be included in routine nightly builds and metrics.


## Subcomponents involved:
- [ ] apply_incr.fd (NOAA-PSL/land-apply_jedi_incr)
- [ ] ufs_model.fd (ufs-community/ufs-weather-model)
- [ ] UFS_UTILS.fd (ufs-community/UFS_UTILS)
- [ ] calcfIMS.fd (NOAA-EPIC/land-SCF_proc)
- [ ] jcb-algorithms (NOAA-EPIC/jcb-algorithms)
- [ ] jcb-gdas (NOAA-EPIC/jcb-gdas)
- [x] none

## Linked PR's and Issues:
<!--
Please link dependent pull requests.
EXAMPLE: Depends on ufs-community/land-DA/pull/<pullrequest_number>

Please link the related issues to be closed with this PR, whether in this repository, or in another repository.
EXAMPLE: Closes ufs-community/land-DA/issues/<issue_number>
-->
Partially satisfies [Platform-1662](https://jira.epic.oarcloud.noaa.gov/browse/PLATFORM-1662)

### Testing (for CM's):
- RDHPCS
    - [ ] Gaea-c6
    - [ ] Hera
    - [ ] Hercules
    - [ ] Orion
    - [ ] Ursa
- CI
  - [ ] Completed
- WE2E
  - [ ] Completed
- PW-Clouds
  - [ ] AWS
  - [ ] AZURE
  - [ ] GCP
